### PR TITLE
feat: add initial project structure with clean architecture

### DIFF
--- a/Backend/.gitignore
+++ b/Backend/.gitignore
@@ -1,0 +1,42 @@
+# Build outputs
+bin/
+obj/
+out/
+
+# Visual Studio
+.vs/
+.vscode/
+
+# User files
+*.user
+*.suo
+
+# Logs
+*.log
+logs/
+
+# Database
+*.db
+*.sqlite
+*.sqlite3
+
+# Environment & secrets
+.env
+appsettings.Development.json
+appsettings.Production.json
+secrets.json
+
+# NuGet
+*.nupkg
+packages/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# JetBrains
+.idea/
+
+# Test results
+TestResults/
+coverage/

--- a/Backend/MiniTwitter.sln
+++ b/Backend/MiniTwitter.sln
@@ -1,0 +1,64 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{E88C2248-7260-498F-B0A2-ED7137591BF9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "core", "core", "{C8E5F41D-2F37-4802-AA10-E53FA8B7D097}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniTwitter.Application", "src\core\MiniTwitter.Application\MiniTwitter.Application.csproj", "{4B98EE26-B608-4AF2-B960-B3AB98011C26}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniTwitter.Domain", "src\core\MiniTwitter.Domain\MiniTwitter.Domain.csproj", "{2F810A96-B6B8-493A-AA1F-6D4268E4EB83}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "infrastructure", "infrastructure", "{FFBA21CE-3463-4BEE-BBFA-52751FDD4C5F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniTwitter.Identity", "src\infrastructure\MiniTwitter.Identity\MiniTwitter.Identity.csproj", "{7F104B59-AA7E-4AE2-A804-FFBEEE62B4D8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniTwitter.Persistence", "src\infrastructure\MiniTwitter.Persistence\MiniTwitter.Persistence.csproj", "{0EB58758-7A7D-49BE-9C93-AB7509361887}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "presentation", "presentation", "{493C3ADB-F672-42A4-837F-3D73C55111F0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniTwitter.WebApi", "src\presentation\MiniTwitter.WebApi\MiniTwitter.WebApi.csproj", "{AB38B6F7-427C-4EE6-B2DD-8EE6937A19A3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4B98EE26-B608-4AF2-B960-B3AB98011C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4B98EE26-B608-4AF2-B960-B3AB98011C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4B98EE26-B608-4AF2-B960-B3AB98011C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4B98EE26-B608-4AF2-B960-B3AB98011C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F810A96-B6B8-493A-AA1F-6D4268E4EB83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F810A96-B6B8-493A-AA1F-6D4268E4EB83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F810A96-B6B8-493A-AA1F-6D4268E4EB83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F810A96-B6B8-493A-AA1F-6D4268E4EB83}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F104B59-AA7E-4AE2-A804-FFBEEE62B4D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F104B59-AA7E-4AE2-A804-FFBEEE62B4D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F104B59-AA7E-4AE2-A804-FFBEEE62B4D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F104B59-AA7E-4AE2-A804-FFBEEE62B4D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EB58758-7A7D-49BE-9C93-AB7509361887}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EB58758-7A7D-49BE-9C93-AB7509361887}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EB58758-7A7D-49BE-9C93-AB7509361887}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EB58758-7A7D-49BE-9C93-AB7509361887}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB38B6F7-427C-4EE6-B2DD-8EE6937A19A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB38B6F7-427C-4EE6-B2DD-8EE6937A19A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB38B6F7-427C-4EE6-B2DD-8EE6937A19A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB38B6F7-427C-4EE6-B2DD-8EE6937A19A3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C8E5F41D-2F37-4802-AA10-E53FA8B7D097} = {E88C2248-7260-498F-B0A2-ED7137591BF9}
+		{4B98EE26-B608-4AF2-B960-B3AB98011C26} = {C8E5F41D-2F37-4802-AA10-E53FA8B7D097}
+		{2F810A96-B6B8-493A-AA1F-6D4268E4EB83} = {C8E5F41D-2F37-4802-AA10-E53FA8B7D097}
+		{FFBA21CE-3463-4BEE-BBFA-52751FDD4C5F} = {E88C2248-7260-498F-B0A2-ED7137591BF9}
+		{7F104B59-AA7E-4AE2-A804-FFBEEE62B4D8} = {FFBA21CE-3463-4BEE-BBFA-52751FDD4C5F}
+		{0EB58758-7A7D-49BE-9C93-AB7509361887} = {FFBA21CE-3463-4BEE-BBFA-52751FDD4C5F}
+		{493C3ADB-F672-42A4-837F-3D73C55111F0} = {E88C2248-7260-498F-B0A2-ED7137591BF9}
+		{AB38B6F7-427C-4EE6-B2DD-8EE6937A19A3} = {493C3ADB-F672-42A4-837F-3D73C55111F0}
+	EndGlobalSection
+EndGlobal

--- a/Backend/global.json
+++ b/Backend/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor"
+  }
+}

--- a/Backend/src/core/MiniTwitter.Application/Class1.cs
+++ b/Backend/src/core/MiniTwitter.Application/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace MiniTwitter.Application;
+
+public class Class1
+{
+
+}

--- a/Backend/src/core/MiniTwitter.Application/MiniTwitter.Application.csproj
+++ b/Backend/src/core/MiniTwitter.Application/MiniTwitter.Application.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\MiniTwitter.Domain\MiniTwitter.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.dgspec.json
+++ b/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.dgspec.json
@@ -1,0 +1,72 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "projectName": "MiniTwitter.Application",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.dgspec.json
+++ b/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.dgspec.json
@@ -31,6 +31,74 @@
         "frameworks": {
           "net8.0": {
             "targetAlias": "net8.0",
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "projectName": "MiniTwitter.Domain",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
             "projectReferences": {}
           }
         },

--- a/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.g.props
+++ b/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.g.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\lTemp\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.11.1</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="C:\Users\lTemp\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+  </ItemGroup>
+</Project>

--- a/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.g.targets
+++ b/Backend/src/core/MiniTwitter.Application/obj/MiniTwitter.Application.csproj.nuget.g.targets
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/Backend/src/core/MiniTwitter.Application/obj/project.assets.json
+++ b/Backend/src/core/MiniTwitter.Application/obj/project.assets.json
@@ -1,0 +1,78 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "net8.0": []
+  },
+  "packageFolders": {
+    "C:\\Users\\lTemp\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+      "projectName": "MiniTwitter.Application",
+      "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+      "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net8.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      }
+    },
+    "frameworks": {
+      "net8.0": {
+        "targetAlias": "net8.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/Backend/src/core/MiniTwitter.Application/obj/project.assets.json
+++ b/Backend/src/core/MiniTwitter.Application/obj/project.assets.json
@@ -1,11 +1,30 @@
 {
   "version": 3,
   "targets": {
-    "net8.0": {}
+    "net8.0": {
+      "MiniTwitter.Domain/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "compile": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        }
+      }
+    }
   },
-  "libraries": {},
+  "libraries": {
+    "MiniTwitter.Domain/1.0.0": {
+      "type": "project",
+      "path": "../MiniTwitter.Domain/MiniTwitter.Domain.csproj",
+      "msbuildProject": "../MiniTwitter.Domain/MiniTwitter.Domain.csproj"
+    }
+  },
   "projectFileDependencyGroups": {
-    "net8.0": []
+    "net8.0": [
+      "MiniTwitter.Domain >= 1.0.0"
+    ]
   },
   "packageFolders": {
     "C:\\Users\\lTemp\\.nuget\\packages\\": {},
@@ -38,7 +57,11 @@
       "frameworks": {
         "net8.0": {
           "targetAlias": "net8.0",
-          "projectReferences": {}
+          "projectReferences": {
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+            }
+          }
         }
       },
       "warningProperties": {

--- a/Backend/src/core/MiniTwitter.Application/obj/project.nuget.cache
+++ b/Backend/src/core/MiniTwitter.Application/obj/project.nuget.cache
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "dgSpecHash": "p6BUUPWhSlM=",
+  "dgSpecHash": "KM1fjgh8b9g=",
   "success": true,
   "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
   "expectedPackageFiles": [],

--- a/Backend/src/core/MiniTwitter.Application/obj/project.nuget.cache
+++ b/Backend/src/core/MiniTwitter.Application/obj/project.nuget.cache
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "dgSpecHash": "p6BUUPWhSlM=",
+  "success": true,
+  "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+  "expectedPackageFiles": [],
+  "logs": []
+}

--- a/Backend/src/core/MiniTwitter.Domain/Class1.cs
+++ b/Backend/src/core/MiniTwitter.Domain/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace MiniTwitter.Domain;
+
+public class Class1
+{
+
+}

--- a/Backend/src/core/MiniTwitter.Domain/MiniTwitter.Domain.csproj
+++ b/Backend/src/core/MiniTwitter.Domain/MiniTwitter.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Backend/src/core/MiniTwitter.Domain/obj/MiniTwitter.Domain.csproj.nuget.dgspec.json
+++ b/Backend/src/core/MiniTwitter.Domain/obj/MiniTwitter.Domain.csproj.nuget.dgspec.json
@@ -1,0 +1,72 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "projectName": "MiniTwitter.Domain",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/Backend/src/core/MiniTwitter.Domain/obj/MiniTwitter.Domain.csproj.nuget.g.props
+++ b/Backend/src/core/MiniTwitter.Domain/obj/MiniTwitter.Domain.csproj.nuget.g.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\lTemp\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.11.1</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="C:\Users\lTemp\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+  </ItemGroup>
+</Project>

--- a/Backend/src/core/MiniTwitter.Domain/obj/MiniTwitter.Domain.csproj.nuget.g.targets
+++ b/Backend/src/core/MiniTwitter.Domain/obj/MiniTwitter.Domain.csproj.nuget.g.targets
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/Backend/src/core/MiniTwitter.Domain/obj/project.assets.json
+++ b/Backend/src/core/MiniTwitter.Domain/obj/project.assets.json
@@ -1,0 +1,78 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "net8.0": []
+  },
+  "packageFolders": {
+    "C:\\Users\\lTemp\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+      "projectName": "MiniTwitter.Domain",
+      "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+      "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net8.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      }
+    },
+    "frameworks": {
+      "net8.0": {
+        "targetAlias": "net8.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/Backend/src/core/MiniTwitter.Domain/obj/project.nuget.cache
+++ b/Backend/src/core/MiniTwitter.Domain/obj/project.nuget.cache
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "dgSpecHash": "W4p0Zb6ksFI=",
+  "success": true,
+  "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+  "expectedPackageFiles": [],
+  "logs": []
+}

--- a/Backend/src/infrastructure/MiniTwitter.Identity/Class1.cs
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace MiniTwitter.Identity;
+
+public class Class1
+{
+
+}

--- a/Backend/src/infrastructure/MiniTwitter.Identity/MiniTwitter.Identity.csproj
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/MiniTwitter.Identity.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\MiniTwitter.Application\MiniTwitter.Application.csproj" />
+    <ProjectReference Include="..\..\core\MiniTwitter.Domain\MiniTwitter.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.dgspec.json
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.dgspec.json
@@ -4,6 +4,138 @@
     "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {}
   },
   "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "projectName": "MiniTwitter.Application",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "projectName": "MiniTwitter.Domain",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
     "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {
       "version": "1.0.0",
       "restore": {
@@ -31,7 +163,14 @@
         "frameworks": {
           "net8.0": {
             "targetAlias": "net8.0",
-            "projectReferences": {}
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+              },
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
           }
         },
         "warningProperties": {

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.dgspec.json
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.dgspec.json
@@ -1,0 +1,72 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+        "projectName": "MiniTwitter.Identity",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.g.props
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.g.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\lTemp\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.11.1</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="C:\Users\lTemp\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+  </ItemGroup>
+</Project>

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.g.targets
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/MiniTwitter.Identity.csproj.nuget.g.targets
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.assets.json
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.assets.json
@@ -1,0 +1,78 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "net8.0": []
+  },
+  "packageFolders": {
+    "C:\\Users\\lTemp\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+      "projectName": "MiniTwitter.Identity",
+      "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+      "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net8.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      }
+    },
+    "frameworks": {
+      "net8.0": {
+        "targetAlias": "net8.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.assets.json
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.assets.json
@@ -1,11 +1,49 @@
 {
   "version": 3,
   "targets": {
-    "net8.0": {}
+    "net8.0": {
+      "MiniTwitter.Application/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "dependencies": {
+          "MiniTwitter.Domain": "1.0.0"
+        },
+        "compile": {
+          "bin/placeholder/MiniTwitter.Application.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Application.dll": {}
+        }
+      },
+      "MiniTwitter.Domain/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "compile": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        }
+      }
+    }
   },
-  "libraries": {},
+  "libraries": {
+    "MiniTwitter.Application/1.0.0": {
+      "type": "project",
+      "path": "../../core/MiniTwitter.Application/MiniTwitter.Application.csproj",
+      "msbuildProject": "../../core/MiniTwitter.Application/MiniTwitter.Application.csproj"
+    },
+    "MiniTwitter.Domain/1.0.0": {
+      "type": "project",
+      "path": "../../core/MiniTwitter.Domain/MiniTwitter.Domain.csproj",
+      "msbuildProject": "../../core/MiniTwitter.Domain/MiniTwitter.Domain.csproj"
+    }
+  },
   "projectFileDependencyGroups": {
-    "net8.0": []
+    "net8.0": [
+      "MiniTwitter.Application >= 1.0.0",
+      "MiniTwitter.Domain >= 1.0.0"
+    ]
   },
   "packageFolders": {
     "C:\\Users\\lTemp\\.nuget\\packages\\": {},
@@ -38,7 +76,14 @@
       "frameworks": {
         "net8.0": {
           "targetAlias": "net8.0",
-          "projectReferences": {}
+          "projectReferences": {
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+            },
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+            }
+          }
         }
       },
       "warningProperties": {

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.nuget.cache
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.nuget.cache
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "dgSpecHash": "y6f0NhQPPyg=",
+  "success": true,
+  "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+  "expectedPackageFiles": [],
+  "logs": []
+}

--- a/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.nuget.cache
+++ b/Backend/src/infrastructure/MiniTwitter.Identity/obj/project.nuget.cache
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "dgSpecHash": "y6f0NhQPPyg=",
+  "dgSpecHash": "Fi6gLPTpQS8=",
   "success": true,
   "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
   "expectedPackageFiles": [],

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/Class1.cs
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace MiniTwitter.Persistence;
+
+public class Class1
+{
+
+}

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/MiniTwitter.Persistence.csproj
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/MiniTwitter.Persistence.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\MiniTwitter.Application\MiniTwitter.Application.csproj" />
+    <ProjectReference Include="..\..\core\MiniTwitter.Domain\MiniTwitter.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.dgspec.json
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.dgspec.json
@@ -1,0 +1,72 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+        "projectName": "MiniTwitter.Persistence",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.dgspec.json
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.dgspec.json
@@ -4,6 +4,138 @@
     "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {}
   },
   "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "projectName": "MiniTwitter.Application",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "projectName": "MiniTwitter.Domain",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
     "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {
       "version": "1.0.0",
       "restore": {
@@ -31,7 +163,14 @@
         "frameworks": {
           "net8.0": {
             "targetAlias": "net8.0",
-            "projectReferences": {}
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+              },
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
           }
         },
         "warningProperties": {

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.g.props
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.g.props
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\lTemp\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.11.1</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="C:\Users\lTemp\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+  </ItemGroup>
+</Project>

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.g.targets
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/MiniTwitter.Persistence.csproj.nuget.g.targets
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" />

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.assets.json
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.assets.json
@@ -1,0 +1,78 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "net8.0": []
+  },
+  "packageFolders": {
+    "C:\\Users\\lTemp\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+      "projectName": "MiniTwitter.Persistence",
+      "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+      "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net8.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      }
+    },
+    "frameworks": {
+      "net8.0": {
+        "targetAlias": "net8.0",
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.assets.json
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.assets.json
@@ -1,11 +1,49 @@
 {
   "version": 3,
   "targets": {
-    "net8.0": {}
+    "net8.0": {
+      "MiniTwitter.Application/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "dependencies": {
+          "MiniTwitter.Domain": "1.0.0"
+        },
+        "compile": {
+          "bin/placeholder/MiniTwitter.Application.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Application.dll": {}
+        }
+      },
+      "MiniTwitter.Domain/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "compile": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        }
+      }
+    }
   },
-  "libraries": {},
+  "libraries": {
+    "MiniTwitter.Application/1.0.0": {
+      "type": "project",
+      "path": "../../core/MiniTwitter.Application/MiniTwitter.Application.csproj",
+      "msbuildProject": "../../core/MiniTwitter.Application/MiniTwitter.Application.csproj"
+    },
+    "MiniTwitter.Domain/1.0.0": {
+      "type": "project",
+      "path": "../../core/MiniTwitter.Domain/MiniTwitter.Domain.csproj",
+      "msbuildProject": "../../core/MiniTwitter.Domain/MiniTwitter.Domain.csproj"
+    }
+  },
   "projectFileDependencyGroups": {
-    "net8.0": []
+    "net8.0": [
+      "MiniTwitter.Application >= 1.0.0",
+      "MiniTwitter.Domain >= 1.0.0"
+    ]
   },
   "packageFolders": {
     "C:\\Users\\lTemp\\.nuget\\packages\\": {},
@@ -38,7 +76,14 @@
       "frameworks": {
         "net8.0": {
           "targetAlias": "net8.0",
-          "projectReferences": {}
+          "projectReferences": {
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+            },
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+            }
+          }
         }
       },
       "warningProperties": {

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.nuget.cache
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.nuget.cache
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "dgSpecHash": "/agS4uGq5KQ=",
+  "dgSpecHash": "NL5zhslFOpo=",
   "success": true,
   "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
   "expectedPackageFiles": [],

--- a/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.nuget.cache
+++ b/Backend/src/infrastructure/MiniTwitter.Persistence/obj/project.nuget.cache
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "dgSpecHash": "/agS4uGq5KQ=",
+  "success": true,
+  "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+  "expectedPackageFiles": [],
+  "logs": []
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/MiniTwitter.WebApi.csproj
+++ b/Backend/src/presentation/MiniTwitter.WebApi/MiniTwitter.WebApi.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\MiniTwitter.Application\MiniTwitter.Application.csproj" />
+    <ProjectReference Include="..\..\infrastructure\MiniTwitter.Identity\MiniTwitter.Identity.csproj" />
+    <ProjectReference Include="..\..\infrastructure\MiniTwitter.Persistence\MiniTwitter.Persistence.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Backend/src/presentation/MiniTwitter.WebApi/MiniTwitter.WebApi.http
+++ b/Backend/src/presentation/MiniTwitter.WebApi/MiniTwitter.WebApi.http
@@ -1,0 +1,6 @@
+@MiniTwitter.WebApi_HostAddress = http://localhost:5258
+
+GET {{MiniTwitter.WebApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/Backend/src/presentation/MiniTwitter.WebApi/Program.cs
+++ b/Backend/src/presentation/MiniTwitter.WebApi/Program.cs
@@ -1,0 +1,44 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast =  Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast")
+.WithOpenApi();
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/Properties/launchSettings.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:42537",
+      "sslPort": 44329
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5258",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7006;http://localhost:5258",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/appsettings.Development.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/appsettings.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.dgspec.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.dgspec.json
@@ -1,0 +1,85 @@
+{
+  "format": 1,
+  "restore": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj": {}
+  },
+  "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj",
+        "projectName": "MiniTwitter.WebApi",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "dependencies": {
+            "Microsoft.AspNetCore.OpenApi": {
+              "target": "Package",
+              "version": "[8.0.11, )"
+            },
+            "Swashbuckle.AspNetCore": {
+              "target": "Package",
+              "version": "[6.6.2, )"
+            }
+          },
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.AspNetCore.App": {
+              "privateAssets": "none"
+            },
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    }
+  }
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.dgspec.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.dgspec.json
@@ -4,6 +4,280 @@
     "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj": {}
   },
   "projects": {
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "projectName": "MiniTwitter.Application",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "projectName": "MiniTwitter.Domain",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {}
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+        "projectName": "MiniTwitter.Identity",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+              },
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
+    "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {
+      "version": "1.0.0",
+      "restore": {
+        "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+        "projectName": "MiniTwitter.Persistence",
+        "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj",
+        "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+        "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\obj\\",
+        "projectStyle": "PackageReference",
+        "fallbackFolders": [
+          "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+        ],
+        "configFilePaths": [
+          "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+          "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+        ],
+        "originalTargetFrameworks": [
+          "net8.0"
+        ],
+        "sources": {
+          "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+          "https://api.nuget.org/v3/index.json": {}
+        },
+        "frameworks": {
+          "net8.0": {
+            "targetAlias": "net8.0",
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+              },
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Domain\\MiniTwitter.Domain.csproj"
+              }
+            }
+          }
+        },
+        "warningProperties": {
+          "warnAsError": [
+            "NU1605"
+          ]
+        },
+        "restoreAuditProperties": {
+          "enableAudit": "true",
+          "auditLevel": "low",
+          "auditMode": "direct"
+        }
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "imports": [
+            "net461",
+            "net462",
+            "net47",
+            "net471",
+            "net472",
+            "net48",
+            "net481"
+          ],
+          "assetTargetFallback": true,
+          "warn": true,
+          "frameworkReferences": {
+            "Microsoft.NETCore.App": {
+              "privateAssets": "all"
+            }
+          },
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+        }
+      }
+    },
     "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj": {
       "version": "1.0.0",
       "restore": {
@@ -31,7 +305,17 @@
         "frameworks": {
           "net8.0": {
             "targetAlias": "net8.0",
-            "projectReferences": {}
+            "projectReferences": {
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+              },
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj"
+              },
+              "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {
+                "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj"
+              }
+            }
           }
         },
         "warningProperties": {

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.g.props
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.g.props
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <RestoreSuccess Condition=" '$(RestoreSuccess)' == '' ">True</RestoreSuccess>
+    <RestoreTool Condition=" '$(RestoreTool)' == '' ">NuGet</RestoreTool>
+    <ProjectAssetsFile Condition=" '$(ProjectAssetsFile)' == '' ">$(MSBuildThisFileDirectory)project.assets.json</ProjectAssetsFile>
+    <NuGetPackageRoot Condition=" '$(NuGetPackageRoot)' == '' ">$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
+    <NuGetPackageFolders Condition=" '$(NuGetPackageFolders)' == '' ">C:\Users\lTemp\.nuget\packages\;C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages</NuGetPackageFolders>
+    <NuGetProjectStyle Condition=" '$(NuGetProjectStyle)' == '' ">PackageReference</NuGetProjectStyle>
+    <NuGetToolVersion Condition=" '$(NuGetToolVersion)' == '' ">6.11.1</NuGetToolVersion>
+  </PropertyGroup>
+  <ItemGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <SourceRoot Include="C:\Users\lTemp\.nuget\packages\" />
+    <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
+  </ItemGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.extensions.apidescription.server\6.0.5\build\Microsoft.Extensions.ApiDescription.Server.props" Condition="Exists('$(NuGetPackageRoot)microsoft.extensions.apidescription.server\6.0.5\build\Microsoft.Extensions.ApiDescription.Server.props')" />
+    <Import Project="$(NuGetPackageRoot)swashbuckle.aspnetcore\6.6.2\build\Swashbuckle.AspNetCore.props" Condition="Exists('$(NuGetPackageRoot)swashbuckle.aspnetcore\6.6.2\build\Swashbuckle.AspNetCore.props')" />
+  </ImportGroup>
+  <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <PkgMicrosoft_Extensions_ApiDescription_Server Condition=" '$(PkgMicrosoft_Extensions_ApiDescription_Server)' == '' ">C:\Users\lTemp\.nuget\packages\microsoft.extensions.apidescription.server\6.0.5</PkgMicrosoft_Extensions_ApiDescription_Server>
+  </PropertyGroup>
+</Project>

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.g.targets
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/MiniTwitter.WebApi.csproj.nuget.g.targets
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.extensions.apidescription.server\6.0.5\build\Microsoft.Extensions.ApiDescription.Server.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.extensions.apidescription.server\6.0.5\build\Microsoft.Extensions.ApiDescription.Server.targets')" />
+  </ImportGroup>
+</Project>

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/project.assets.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/project.assets.json
@@ -107,6 +107,57 @@
         "frameworkReferences": [
           "Microsoft.AspNetCore.App"
         ]
+      },
+      "MiniTwitter.Application/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "dependencies": {
+          "MiniTwitter.Domain": "1.0.0"
+        },
+        "compile": {
+          "bin/placeholder/MiniTwitter.Application.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Application.dll": {}
+        }
+      },
+      "MiniTwitter.Domain/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "compile": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Domain.dll": {}
+        }
+      },
+      "MiniTwitter.Identity/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "dependencies": {
+          "MiniTwitter.Application": "1.0.0",
+          "MiniTwitter.Domain": "1.0.0"
+        },
+        "compile": {
+          "bin/placeholder/MiniTwitter.Identity.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Identity.dll": {}
+        }
+      },
+      "MiniTwitter.Persistence/1.0.0": {
+        "type": "project",
+        "framework": ".NETCoreApp,Version=v8.0",
+        "dependencies": {
+          "MiniTwitter.Application": "1.0.0",
+          "MiniTwitter.Domain": "1.0.0"
+        },
+        "compile": {
+          "bin/placeholder/MiniTwitter.Persistence.dll": {}
+        },
+        "runtime": {
+          "bin/placeholder/MiniTwitter.Persistence.dll": {}
+        }
       }
     }
   },
@@ -473,11 +524,34 @@
         "swashbuckle.aspnetcore.swaggerui.6.6.2.nupkg.sha512",
         "swashbuckle.aspnetcore.swaggerui.nuspec"
       ]
+    },
+    "MiniTwitter.Application/1.0.0": {
+      "type": "project",
+      "path": "../../core/MiniTwitter.Application/MiniTwitter.Application.csproj",
+      "msbuildProject": "../../core/MiniTwitter.Application/MiniTwitter.Application.csproj"
+    },
+    "MiniTwitter.Domain/1.0.0": {
+      "type": "project",
+      "path": "../../core/MiniTwitter.Domain/MiniTwitter.Domain.csproj",
+      "msbuildProject": "../../core/MiniTwitter.Domain/MiniTwitter.Domain.csproj"
+    },
+    "MiniTwitter.Identity/1.0.0": {
+      "type": "project",
+      "path": "../../infrastructure/MiniTwitter.Identity/MiniTwitter.Identity.csproj",
+      "msbuildProject": "../../infrastructure/MiniTwitter.Identity/MiniTwitter.Identity.csproj"
+    },
+    "MiniTwitter.Persistence/1.0.0": {
+      "type": "project",
+      "path": "../../infrastructure/MiniTwitter.Persistence/MiniTwitter.Persistence.csproj",
+      "msbuildProject": "../../infrastructure/MiniTwitter.Persistence/MiniTwitter.Persistence.csproj"
     }
   },
   "projectFileDependencyGroups": {
     "net8.0": [
       "Microsoft.AspNetCore.OpenApi >= 8.0.11",
+      "MiniTwitter.Application >= 1.0.0",
+      "MiniTwitter.Identity >= 1.0.0",
+      "MiniTwitter.Persistence >= 1.0.0",
       "Swashbuckle.AspNetCore >= 6.6.2"
     ]
   },
@@ -512,7 +586,17 @@
       "frameworks": {
         "net8.0": {
           "targetAlias": "net8.0",
-          "projectReferences": {}
+          "projectReferences": {
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\core\\MiniTwitter.Application\\MiniTwitter.Application.csproj"
+            },
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Identity\\MiniTwitter.Identity.csproj"
+            },
+            "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj": {
+              "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\infrastructure\\MiniTwitter.Persistence\\MiniTwitter.Persistence.csproj"
+            }
+          }
         }
       },
       "warningProperties": {

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/project.assets.json
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/project.assets.json
@@ -1,0 +1,565 @@
+{
+  "version": 3,
+  "targets": {
+    "net8.0": {
+      "Microsoft.AspNetCore.OpenApi/8.0.11": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.4.3"
+        },
+        "compile": {
+          "lib/net8.0/Microsoft.AspNetCore.OpenApi.dll": {
+            "related": ".xml"
+          }
+        },
+        "runtime": {
+          "lib/net8.0/Microsoft.AspNetCore.OpenApi.dll": {
+            "related": ".xml"
+          }
+        },
+        "frameworkReferences": [
+          "Microsoft.AspNetCore.App"
+        ]
+      },
+      "Microsoft.Extensions.ApiDescription.Server/6.0.5": {
+        "type": "package",
+        "build": {
+          "build/Microsoft.Extensions.ApiDescription.Server.props": {},
+          "build/Microsoft.Extensions.ApiDescription.Server.targets": {}
+        },
+        "buildMultiTargeting": {
+          "buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.props": {},
+          "buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets": {}
+        }
+      },
+      "Microsoft.OpenApi/1.6.14": {
+        "type": "package",
+        "compile": {
+          "lib/netstandard2.0/Microsoft.OpenApi.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.OpenApi.dll": {
+            "related": ".pdb;.xml"
+          }
+        }
+      },
+      "Swashbuckle.AspNetCore/6.6.2": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Extensions.ApiDescription.Server": "6.0.5",
+          "Swashbuckle.AspNetCore.Swagger": "6.6.2",
+          "Swashbuckle.AspNetCore.SwaggerGen": "6.6.2",
+          "Swashbuckle.AspNetCore.SwaggerUI": "6.6.2"
+        },
+        "build": {
+          "build/Swashbuckle.AspNetCore.props": {}
+        }
+      },
+      "Swashbuckle.AspNetCore.Swagger/6.6.2": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.OpenApi": "1.6.14"
+        },
+        "compile": {
+          "lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "runtime": {
+          "lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "frameworkReferences": [
+          "Microsoft.AspNetCore.App"
+        ]
+      },
+      "Swashbuckle.AspNetCore.SwaggerGen/6.6.2": {
+        "type": "package",
+        "dependencies": {
+          "Swashbuckle.AspNetCore.Swagger": "6.6.2"
+        },
+        "compile": {
+          "lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "runtime": {
+          "lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll": {
+            "related": ".pdb;.xml"
+          }
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI/6.6.2": {
+        "type": "package",
+        "compile": {
+          "lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "runtime": {
+          "lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll": {
+            "related": ".pdb;.xml"
+          }
+        },
+        "frameworkReferences": [
+          "Microsoft.AspNetCore.App"
+        ]
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.AspNetCore.OpenApi/8.0.11": {
+      "sha512": "1WCvCZpqvOAyul6upSJ8Rkb/QHdr4PLrDny26vFexya/nTkG3x2zt8j9qlJ5T3J+/yJD9KwlGKhho9ZDD/YiFA==",
+      "type": "package",
+      "path": "microsoft.aspnetcore.openapi/8.0.11",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "Icon.png",
+        "THIRD-PARTY-NOTICES.TXT",
+        "lib/net8.0/Microsoft.AspNetCore.OpenApi.dll",
+        "lib/net8.0/Microsoft.AspNetCore.OpenApi.xml",
+        "microsoft.aspnetcore.openapi.8.0.11.nupkg.sha512",
+        "microsoft.aspnetcore.openapi.nuspec"
+      ]
+    },
+    "Microsoft.Extensions.ApiDescription.Server/6.0.5": {
+      "sha512": "Ckb5EDBUNJdFWyajfXzUIMRkhf52fHZOQuuZg/oiu8y7zDCVwD0iHhew6MnThjHmevanpxL3f5ci2TtHQEN6bw==",
+      "type": "package",
+      "path": "microsoft.extensions.apidescription.server/6.0.5",
+      "hasTools": true,
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "Icon.png",
+        "build/Microsoft.Extensions.ApiDescription.Server.props",
+        "build/Microsoft.Extensions.ApiDescription.Server.targets",
+        "buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.props",
+        "buildMultiTargeting/Microsoft.Extensions.ApiDescription.Server.targets",
+        "microsoft.extensions.apidescription.server.6.0.5.nupkg.sha512",
+        "microsoft.extensions.apidescription.server.nuspec",
+        "tools/Newtonsoft.Json.dll",
+        "tools/dotnet-getdocument.deps.json",
+        "tools/dotnet-getdocument.dll",
+        "tools/dotnet-getdocument.runtimeconfig.json",
+        "tools/net461-x86/GetDocument.Insider.exe",
+        "tools/net461-x86/GetDocument.Insider.exe.config",
+        "tools/net461-x86/Microsoft.Win32.Primitives.dll",
+        "tools/net461-x86/System.AppContext.dll",
+        "tools/net461-x86/System.Buffers.dll",
+        "tools/net461-x86/System.Collections.Concurrent.dll",
+        "tools/net461-x86/System.Collections.NonGeneric.dll",
+        "tools/net461-x86/System.Collections.Specialized.dll",
+        "tools/net461-x86/System.Collections.dll",
+        "tools/net461-x86/System.ComponentModel.EventBasedAsync.dll",
+        "tools/net461-x86/System.ComponentModel.Primitives.dll",
+        "tools/net461-x86/System.ComponentModel.TypeConverter.dll",
+        "tools/net461-x86/System.ComponentModel.dll",
+        "tools/net461-x86/System.Console.dll",
+        "tools/net461-x86/System.Data.Common.dll",
+        "tools/net461-x86/System.Diagnostics.Contracts.dll",
+        "tools/net461-x86/System.Diagnostics.Debug.dll",
+        "tools/net461-x86/System.Diagnostics.DiagnosticSource.dll",
+        "tools/net461-x86/System.Diagnostics.FileVersionInfo.dll",
+        "tools/net461-x86/System.Diagnostics.Process.dll",
+        "tools/net461-x86/System.Diagnostics.StackTrace.dll",
+        "tools/net461-x86/System.Diagnostics.TextWriterTraceListener.dll",
+        "tools/net461-x86/System.Diagnostics.Tools.dll",
+        "tools/net461-x86/System.Diagnostics.TraceSource.dll",
+        "tools/net461-x86/System.Diagnostics.Tracing.dll",
+        "tools/net461-x86/System.Drawing.Primitives.dll",
+        "tools/net461-x86/System.Dynamic.Runtime.dll",
+        "tools/net461-x86/System.Globalization.Calendars.dll",
+        "tools/net461-x86/System.Globalization.Extensions.dll",
+        "tools/net461-x86/System.Globalization.dll",
+        "tools/net461-x86/System.IO.Compression.ZipFile.dll",
+        "tools/net461-x86/System.IO.Compression.dll",
+        "tools/net461-x86/System.IO.FileSystem.DriveInfo.dll",
+        "tools/net461-x86/System.IO.FileSystem.Primitives.dll",
+        "tools/net461-x86/System.IO.FileSystem.Watcher.dll",
+        "tools/net461-x86/System.IO.FileSystem.dll",
+        "tools/net461-x86/System.IO.IsolatedStorage.dll",
+        "tools/net461-x86/System.IO.MemoryMappedFiles.dll",
+        "tools/net461-x86/System.IO.Pipes.dll",
+        "tools/net461-x86/System.IO.UnmanagedMemoryStream.dll",
+        "tools/net461-x86/System.IO.dll",
+        "tools/net461-x86/System.Linq.Expressions.dll",
+        "tools/net461-x86/System.Linq.Parallel.dll",
+        "tools/net461-x86/System.Linq.Queryable.dll",
+        "tools/net461-x86/System.Linq.dll",
+        "tools/net461-x86/System.Memory.dll",
+        "tools/net461-x86/System.Net.Http.dll",
+        "tools/net461-x86/System.Net.NameResolution.dll",
+        "tools/net461-x86/System.Net.NetworkInformation.dll",
+        "tools/net461-x86/System.Net.Ping.dll",
+        "tools/net461-x86/System.Net.Primitives.dll",
+        "tools/net461-x86/System.Net.Requests.dll",
+        "tools/net461-x86/System.Net.Security.dll",
+        "tools/net461-x86/System.Net.Sockets.dll",
+        "tools/net461-x86/System.Net.WebHeaderCollection.dll",
+        "tools/net461-x86/System.Net.WebSockets.Client.dll",
+        "tools/net461-x86/System.Net.WebSockets.dll",
+        "tools/net461-x86/System.Numerics.Vectors.dll",
+        "tools/net461-x86/System.ObjectModel.dll",
+        "tools/net461-x86/System.Reflection.Extensions.dll",
+        "tools/net461-x86/System.Reflection.Primitives.dll",
+        "tools/net461-x86/System.Reflection.dll",
+        "tools/net461-x86/System.Resources.Reader.dll",
+        "tools/net461-x86/System.Resources.ResourceManager.dll",
+        "tools/net461-x86/System.Resources.Writer.dll",
+        "tools/net461-x86/System.Runtime.CompilerServices.Unsafe.dll",
+        "tools/net461-x86/System.Runtime.CompilerServices.VisualC.dll",
+        "tools/net461-x86/System.Runtime.Extensions.dll",
+        "tools/net461-x86/System.Runtime.Handles.dll",
+        "tools/net461-x86/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "tools/net461-x86/System.Runtime.InteropServices.dll",
+        "tools/net461-x86/System.Runtime.Numerics.dll",
+        "tools/net461-x86/System.Runtime.Serialization.Formatters.dll",
+        "tools/net461-x86/System.Runtime.Serialization.Json.dll",
+        "tools/net461-x86/System.Runtime.Serialization.Primitives.dll",
+        "tools/net461-x86/System.Runtime.Serialization.Xml.dll",
+        "tools/net461-x86/System.Runtime.dll",
+        "tools/net461-x86/System.Security.Claims.dll",
+        "tools/net461-x86/System.Security.Cryptography.Algorithms.dll",
+        "tools/net461-x86/System.Security.Cryptography.Csp.dll",
+        "tools/net461-x86/System.Security.Cryptography.Encoding.dll",
+        "tools/net461-x86/System.Security.Cryptography.Primitives.dll",
+        "tools/net461-x86/System.Security.Cryptography.X509Certificates.dll",
+        "tools/net461-x86/System.Security.Principal.dll",
+        "tools/net461-x86/System.Security.SecureString.dll",
+        "tools/net461-x86/System.Text.Encoding.Extensions.dll",
+        "tools/net461-x86/System.Text.Encoding.dll",
+        "tools/net461-x86/System.Text.RegularExpressions.dll",
+        "tools/net461-x86/System.Threading.Overlapped.dll",
+        "tools/net461-x86/System.Threading.Tasks.Parallel.dll",
+        "tools/net461-x86/System.Threading.Tasks.dll",
+        "tools/net461-x86/System.Threading.Thread.dll",
+        "tools/net461-x86/System.Threading.ThreadPool.dll",
+        "tools/net461-x86/System.Threading.Timer.dll",
+        "tools/net461-x86/System.Threading.dll",
+        "tools/net461-x86/System.ValueTuple.dll",
+        "tools/net461-x86/System.Xml.ReaderWriter.dll",
+        "tools/net461-x86/System.Xml.XDocument.dll",
+        "tools/net461-x86/System.Xml.XPath.XDocument.dll",
+        "tools/net461-x86/System.Xml.XPath.dll",
+        "tools/net461-x86/System.Xml.XmlDocument.dll",
+        "tools/net461-x86/System.Xml.XmlSerializer.dll",
+        "tools/net461-x86/netstandard.dll",
+        "tools/net461/GetDocument.Insider.exe",
+        "tools/net461/GetDocument.Insider.exe.config",
+        "tools/net461/Microsoft.Win32.Primitives.dll",
+        "tools/net461/System.AppContext.dll",
+        "tools/net461/System.Buffers.dll",
+        "tools/net461/System.Collections.Concurrent.dll",
+        "tools/net461/System.Collections.NonGeneric.dll",
+        "tools/net461/System.Collections.Specialized.dll",
+        "tools/net461/System.Collections.dll",
+        "tools/net461/System.ComponentModel.EventBasedAsync.dll",
+        "tools/net461/System.ComponentModel.Primitives.dll",
+        "tools/net461/System.ComponentModel.TypeConverter.dll",
+        "tools/net461/System.ComponentModel.dll",
+        "tools/net461/System.Console.dll",
+        "tools/net461/System.Data.Common.dll",
+        "tools/net461/System.Diagnostics.Contracts.dll",
+        "tools/net461/System.Diagnostics.Debug.dll",
+        "tools/net461/System.Diagnostics.DiagnosticSource.dll",
+        "tools/net461/System.Diagnostics.FileVersionInfo.dll",
+        "tools/net461/System.Diagnostics.Process.dll",
+        "tools/net461/System.Diagnostics.StackTrace.dll",
+        "tools/net461/System.Diagnostics.TextWriterTraceListener.dll",
+        "tools/net461/System.Diagnostics.Tools.dll",
+        "tools/net461/System.Diagnostics.TraceSource.dll",
+        "tools/net461/System.Diagnostics.Tracing.dll",
+        "tools/net461/System.Drawing.Primitives.dll",
+        "tools/net461/System.Dynamic.Runtime.dll",
+        "tools/net461/System.Globalization.Calendars.dll",
+        "tools/net461/System.Globalization.Extensions.dll",
+        "tools/net461/System.Globalization.dll",
+        "tools/net461/System.IO.Compression.ZipFile.dll",
+        "tools/net461/System.IO.Compression.dll",
+        "tools/net461/System.IO.FileSystem.DriveInfo.dll",
+        "tools/net461/System.IO.FileSystem.Primitives.dll",
+        "tools/net461/System.IO.FileSystem.Watcher.dll",
+        "tools/net461/System.IO.FileSystem.dll",
+        "tools/net461/System.IO.IsolatedStorage.dll",
+        "tools/net461/System.IO.MemoryMappedFiles.dll",
+        "tools/net461/System.IO.Pipes.dll",
+        "tools/net461/System.IO.UnmanagedMemoryStream.dll",
+        "tools/net461/System.IO.dll",
+        "tools/net461/System.Linq.Expressions.dll",
+        "tools/net461/System.Linq.Parallel.dll",
+        "tools/net461/System.Linq.Queryable.dll",
+        "tools/net461/System.Linq.dll",
+        "tools/net461/System.Memory.dll",
+        "tools/net461/System.Net.Http.dll",
+        "tools/net461/System.Net.NameResolution.dll",
+        "tools/net461/System.Net.NetworkInformation.dll",
+        "tools/net461/System.Net.Ping.dll",
+        "tools/net461/System.Net.Primitives.dll",
+        "tools/net461/System.Net.Requests.dll",
+        "tools/net461/System.Net.Security.dll",
+        "tools/net461/System.Net.Sockets.dll",
+        "tools/net461/System.Net.WebHeaderCollection.dll",
+        "tools/net461/System.Net.WebSockets.Client.dll",
+        "tools/net461/System.Net.WebSockets.dll",
+        "tools/net461/System.Numerics.Vectors.dll",
+        "tools/net461/System.ObjectModel.dll",
+        "tools/net461/System.Reflection.Extensions.dll",
+        "tools/net461/System.Reflection.Primitives.dll",
+        "tools/net461/System.Reflection.dll",
+        "tools/net461/System.Resources.Reader.dll",
+        "tools/net461/System.Resources.ResourceManager.dll",
+        "tools/net461/System.Resources.Writer.dll",
+        "tools/net461/System.Runtime.CompilerServices.Unsafe.dll",
+        "tools/net461/System.Runtime.CompilerServices.VisualC.dll",
+        "tools/net461/System.Runtime.Extensions.dll",
+        "tools/net461/System.Runtime.Handles.dll",
+        "tools/net461/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "tools/net461/System.Runtime.InteropServices.dll",
+        "tools/net461/System.Runtime.Numerics.dll",
+        "tools/net461/System.Runtime.Serialization.Formatters.dll",
+        "tools/net461/System.Runtime.Serialization.Json.dll",
+        "tools/net461/System.Runtime.Serialization.Primitives.dll",
+        "tools/net461/System.Runtime.Serialization.Xml.dll",
+        "tools/net461/System.Runtime.dll",
+        "tools/net461/System.Security.Claims.dll",
+        "tools/net461/System.Security.Cryptography.Algorithms.dll",
+        "tools/net461/System.Security.Cryptography.Csp.dll",
+        "tools/net461/System.Security.Cryptography.Encoding.dll",
+        "tools/net461/System.Security.Cryptography.Primitives.dll",
+        "tools/net461/System.Security.Cryptography.X509Certificates.dll",
+        "tools/net461/System.Security.Principal.dll",
+        "tools/net461/System.Security.SecureString.dll",
+        "tools/net461/System.Text.Encoding.Extensions.dll",
+        "tools/net461/System.Text.Encoding.dll",
+        "tools/net461/System.Text.RegularExpressions.dll",
+        "tools/net461/System.Threading.Overlapped.dll",
+        "tools/net461/System.Threading.Tasks.Parallel.dll",
+        "tools/net461/System.Threading.Tasks.dll",
+        "tools/net461/System.Threading.Thread.dll",
+        "tools/net461/System.Threading.ThreadPool.dll",
+        "tools/net461/System.Threading.Timer.dll",
+        "tools/net461/System.Threading.dll",
+        "tools/net461/System.ValueTuple.dll",
+        "tools/net461/System.Xml.ReaderWriter.dll",
+        "tools/net461/System.Xml.XDocument.dll",
+        "tools/net461/System.Xml.XPath.XDocument.dll",
+        "tools/net461/System.Xml.XPath.dll",
+        "tools/net461/System.Xml.XmlDocument.dll",
+        "tools/net461/System.Xml.XmlSerializer.dll",
+        "tools/net461/netstandard.dll",
+        "tools/netcoreapp2.1/GetDocument.Insider.deps.json",
+        "tools/netcoreapp2.1/GetDocument.Insider.dll",
+        "tools/netcoreapp2.1/GetDocument.Insider.runtimeconfig.json",
+        "tools/netcoreapp2.1/System.Diagnostics.DiagnosticSource.dll"
+      ]
+    },
+    "Microsoft.OpenApi/1.6.14": {
+      "sha512": "tTaBT8qjk3xINfESyOPE2rIellPvB7qpVqiWiyA/lACVvz+xOGiXhFUfohcx82NLbi5avzLW0lx+s6oAqQijfw==",
+      "type": "package",
+      "path": "microsoft.openapi/1.6.14",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "README.md",
+        "lib/netstandard2.0/Microsoft.OpenApi.dll",
+        "lib/netstandard2.0/Microsoft.OpenApi.pdb",
+        "lib/netstandard2.0/Microsoft.OpenApi.xml",
+        "microsoft.openapi.1.6.14.nupkg.sha512",
+        "microsoft.openapi.nuspec"
+      ]
+    },
+    "Swashbuckle.AspNetCore/6.6.2": {
+      "sha512": "+NB4UYVYN6AhDSjW0IJAd1AGD8V33gemFNLPaxKTtPkHB+HaKAKf9MGAEUPivEWvqeQfcKIw8lJaHq6LHljRuw==",
+      "type": "package",
+      "path": "swashbuckle.aspnetcore/6.6.2",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "build/Swashbuckle.AspNetCore.props",
+        "swashbuckle.aspnetcore.6.6.2.nupkg.sha512",
+        "swashbuckle.aspnetcore.nuspec"
+      ]
+    },
+    "Swashbuckle.AspNetCore.Swagger/6.6.2": {
+      "sha512": "ovgPTSYX83UrQUWiS5vzDcJ8TEX1MAxBgDFMK45rC24MorHEPQlZAHlaXj/yth4Zf6xcktpUgTEBvffRQVwDKA==",
+      "type": "package",
+      "path": "swashbuckle.aspnetcore.swagger/6.6.2",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "lib/net5.0/Swashbuckle.AspNetCore.Swagger.dll",
+        "lib/net5.0/Swashbuckle.AspNetCore.Swagger.pdb",
+        "lib/net5.0/Swashbuckle.AspNetCore.Swagger.xml",
+        "lib/net6.0/Swashbuckle.AspNetCore.Swagger.dll",
+        "lib/net6.0/Swashbuckle.AspNetCore.Swagger.pdb",
+        "lib/net6.0/Swashbuckle.AspNetCore.Swagger.xml",
+        "lib/net7.0/Swashbuckle.AspNetCore.Swagger.dll",
+        "lib/net7.0/Swashbuckle.AspNetCore.Swagger.pdb",
+        "lib/net7.0/Swashbuckle.AspNetCore.Swagger.xml",
+        "lib/net8.0/Swashbuckle.AspNetCore.Swagger.dll",
+        "lib/net8.0/Swashbuckle.AspNetCore.Swagger.pdb",
+        "lib/net8.0/Swashbuckle.AspNetCore.Swagger.xml",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.Swagger.dll",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.Swagger.pdb",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.Swagger.xml",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.Swagger.dll",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.Swagger.pdb",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.Swagger.xml",
+        "package-readme.md",
+        "swashbuckle.aspnetcore.swagger.6.6.2.nupkg.sha512",
+        "swashbuckle.aspnetcore.swagger.nuspec"
+      ]
+    },
+    "Swashbuckle.AspNetCore.SwaggerGen/6.6.2": {
+      "sha512": "zv4ikn4AT1VYuOsDCpktLq4QDq08e7Utzbir86M5/ZkRaLXbCPF11E1/vTmOiDzRTl0zTZINQU2qLKwTcHgfrA==",
+      "type": "package",
+      "path": "swashbuckle.aspnetcore.swaggergen/6.6.2",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "lib/net5.0/Swashbuckle.AspNetCore.SwaggerGen.dll",
+        "lib/net5.0/Swashbuckle.AspNetCore.SwaggerGen.pdb",
+        "lib/net5.0/Swashbuckle.AspNetCore.SwaggerGen.xml",
+        "lib/net6.0/Swashbuckle.AspNetCore.SwaggerGen.dll",
+        "lib/net6.0/Swashbuckle.AspNetCore.SwaggerGen.pdb",
+        "lib/net6.0/Swashbuckle.AspNetCore.SwaggerGen.xml",
+        "lib/net7.0/Swashbuckle.AspNetCore.SwaggerGen.dll",
+        "lib/net7.0/Swashbuckle.AspNetCore.SwaggerGen.pdb",
+        "lib/net7.0/Swashbuckle.AspNetCore.SwaggerGen.xml",
+        "lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.dll",
+        "lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.pdb",
+        "lib/net8.0/Swashbuckle.AspNetCore.SwaggerGen.xml",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerGen.dll",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerGen.pdb",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerGen.xml",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.SwaggerGen.dll",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.SwaggerGen.pdb",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.SwaggerGen.xml",
+        "package-readme.md",
+        "swashbuckle.aspnetcore.swaggergen.6.6.2.nupkg.sha512",
+        "swashbuckle.aspnetcore.swaggergen.nuspec"
+      ]
+    },
+    "Swashbuckle.AspNetCore.SwaggerUI/6.6.2": {
+      "sha512": "mBBb+/8Hm2Q3Wygag+hu2jj69tZW5psuv0vMRXY07Wy+Rrj40vRP8ZTbKBhs91r45/HXT4aY4z0iSBYx1h6JvA==",
+      "type": "package",
+      "path": "swashbuckle.aspnetcore.swaggerui/6.6.2",
+      "files": [
+        ".nupkg.metadata",
+        ".signature.p7s",
+        "lib/net5.0/Swashbuckle.AspNetCore.SwaggerUI.dll",
+        "lib/net5.0/Swashbuckle.AspNetCore.SwaggerUI.pdb",
+        "lib/net5.0/Swashbuckle.AspNetCore.SwaggerUI.xml",
+        "lib/net6.0/Swashbuckle.AspNetCore.SwaggerUI.dll",
+        "lib/net6.0/Swashbuckle.AspNetCore.SwaggerUI.pdb",
+        "lib/net6.0/Swashbuckle.AspNetCore.SwaggerUI.xml",
+        "lib/net7.0/Swashbuckle.AspNetCore.SwaggerUI.dll",
+        "lib/net7.0/Swashbuckle.AspNetCore.SwaggerUI.pdb",
+        "lib/net7.0/Swashbuckle.AspNetCore.SwaggerUI.xml",
+        "lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.dll",
+        "lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.pdb",
+        "lib/net8.0/Swashbuckle.AspNetCore.SwaggerUI.xml",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerUI.dll",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerUI.pdb",
+        "lib/netcoreapp3.0/Swashbuckle.AspNetCore.SwaggerUI.xml",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.SwaggerUI.dll",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.SwaggerUI.pdb",
+        "lib/netstandard2.0/Swashbuckle.AspNetCore.SwaggerUI.xml",
+        "package-readme.md",
+        "swashbuckle.aspnetcore.swaggerui.6.6.2.nupkg.sha512",
+        "swashbuckle.aspnetcore.swaggerui.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "net8.0": [
+      "Microsoft.AspNetCore.OpenApi >= 8.0.11",
+      "Swashbuckle.AspNetCore >= 6.6.2"
+    ]
+  },
+  "packageFolders": {
+    "C:\\Users\\lTemp\\.nuget\\packages\\": {},
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
+  },
+  "project": {
+    "version": "1.0.0",
+    "restore": {
+      "projectUniqueName": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj",
+      "projectName": "MiniTwitter.WebApi",
+      "projectPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj",
+      "packagesPath": "C:\\Users\\lTemp\\.nuget\\packages\\",
+      "outputPath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\obj\\",
+      "projectStyle": "PackageReference",
+      "fallbackFolders": [
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
+      ],
+      "configFilePaths": [
+        "C:\\Users\\lTemp\\AppData\\Roaming\\NuGet\\NuGet.Config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.FallbackLocation.config",
+        "C:\\Program Files (x86)\\NuGet\\Config\\Microsoft.VisualStudio.Offline.config"
+      ],
+      "originalTargetFrameworks": [
+        "net8.0"
+      ],
+      "sources": {
+        "C:\\Program Files (x86)\\Microsoft SDKs\\NuGetPackages\\": {},
+        "https://api.nuget.org/v3/index.json": {}
+      },
+      "frameworks": {
+        "net8.0": {
+          "targetAlias": "net8.0",
+          "projectReferences": {}
+        }
+      },
+      "warningProperties": {
+        "warnAsError": [
+          "NU1605"
+        ]
+      },
+      "restoreAuditProperties": {
+        "enableAudit": "true",
+        "auditLevel": "low",
+        "auditMode": "direct"
+      }
+    },
+    "frameworks": {
+      "net8.0": {
+        "targetAlias": "net8.0",
+        "dependencies": {
+          "Microsoft.AspNetCore.OpenApi": {
+            "target": "Package",
+            "version": "[8.0.11, )"
+          },
+          "Swashbuckle.AspNetCore": {
+            "target": "Package",
+            "version": "[6.6.2, )"
+          }
+        },
+        "imports": [
+          "net461",
+          "net462",
+          "net47",
+          "net471",
+          "net472",
+          "net48",
+          "net481"
+        ],
+        "assetTargetFallback": true,
+        "warn": true,
+        "frameworkReferences": {
+          "Microsoft.AspNetCore.App": {
+            "privateAssets": "none"
+          },
+          "Microsoft.NETCore.App": {
+            "privateAssets": "all"
+          }
+        },
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\8.0.404/PortableRuntimeIdentifierGraph.json"
+      }
+    }
+  }
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/project.nuget.cache
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/project.nuget.cache
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "dgSpecHash": "+Pnf6qXRv6M=",
+  "success": true,
+  "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj",
+  "expectedPackageFiles": [
+    "C:\\Users\\lTemp\\.nuget\\packages\\microsoft.aspnetcore.openapi\\8.0.11\\microsoft.aspnetcore.openapi.8.0.11.nupkg.sha512",
+    "C:\\Users\\lTemp\\.nuget\\packages\\microsoft.extensions.apidescription.server\\6.0.5\\microsoft.extensions.apidescription.server.6.0.5.nupkg.sha512",
+    "C:\\Users\\lTemp\\.nuget\\packages\\microsoft.openapi\\1.6.14\\microsoft.openapi.1.6.14.nupkg.sha512",
+    "C:\\Users\\lTemp\\.nuget\\packages\\swashbuckle.aspnetcore\\6.6.2\\swashbuckle.aspnetcore.6.6.2.nupkg.sha512",
+    "C:\\Users\\lTemp\\.nuget\\packages\\swashbuckle.aspnetcore.swagger\\6.6.2\\swashbuckle.aspnetcore.swagger.6.6.2.nupkg.sha512",
+    "C:\\Users\\lTemp\\.nuget\\packages\\swashbuckle.aspnetcore.swaggergen\\6.6.2\\swashbuckle.aspnetcore.swaggergen.6.6.2.nupkg.sha512",
+    "C:\\Users\\lTemp\\.nuget\\packages\\swashbuckle.aspnetcore.swaggerui\\6.6.2\\swashbuckle.aspnetcore.swaggerui.6.6.2.nupkg.sha512"
+  ],
+  "logs": []
+}

--- a/Backend/src/presentation/MiniTwitter.WebApi/obj/project.nuget.cache
+++ b/Backend/src/presentation/MiniTwitter.WebApi/obj/project.nuget.cache
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "dgSpecHash": "+Pnf6qXRv6M=",
+  "dgSpecHash": "isEZlDLozR4=",
   "success": true,
   "projectFilePath": "C:\\Users\\lTemp\\Desktop\\Coding\\cds-projects\\Mini-Twitter-V1\\Backend\\src\\presentation\\MiniTwitter.WebApi\\MiniTwitter.WebApi.csproj",
   "expectedPackageFiles": [


### PR DESCRIPTION
- Create solution with 5 projects following clean architecture
- Add core layer: Domain and Application projects
- Add infrastructure layer: Identity and Persistence projects
- Add presentation layer: WebApi project
- Configure project dependencies and references